### PR TITLE
Fix asset cache path overriding

### DIFF
--- a/Plugins/HoudiniEngineUnity/Scripts/Core/HEU_AssetDatabase.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Core/HEU_AssetDatabase.cs
@@ -50,7 +50,7 @@ namespace HoudiniEngineUnity
 			string rootPath = HEU_Platform.BuildPath("Assets", HEU_PluginSettings.AssetCachePath);
 			if (!AssetDatabase.IsValidFolder(rootPath))
 			{
-				AssetDatabase.CreateFolder("Assets", HEU_PluginSettings.AssetCachePath);
+				CreatePathWithFolders(rootPath);
 			}
 
 			return rootPath;


### PR DESCRIPTION
Asset cache folder was assumed to be placed directly in the 'Assets'
folder. This caused issue when asset cache path was overriden.