### PR TITLE
Add conditional compilation for VisualScripting support.

### DIFF
--- a/Plugins/HoudiniEngineUnity/Editor/HoudiniEngineUnityEditor.asmdef
+++ b/Plugins/HoudiniEngineUnity/Editor/HoudiniEngineUnityEditor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "HoudiniEngineUnityEditor",
+    "rootNamespace": "",
     "references": [
         "HoudiniEngineUnity"
     ],

--- a/Plugins/HoudiniEngineUnity/Editor/VisualScripting/HoudiniEngineUnityEditor.VisualScripting.asmdef
+++ b/Plugins/HoudiniEngineUnity/Editor/VisualScripting/HoudiniEngineUnityEditor.VisualScripting.asmdef
@@ -19,7 +19,15 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
+    "defineConstraints": [
+        "HAS_VISUALSCRIPTING"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.visualscripting",
+            "expression": "1.5.0",
+            "define": "HAS_VISUALSCRIPTING"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Plugins/HoudiniEngineUnity/Scripts/HoudiniEngineUnity.asmdef
+++ b/Plugins/HoudiniEngineUnity/Scripts/HoudiniEngineUnity.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "HoudiniEngineUnity",
+    "rootNamespace": "",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Plugins/HoudiniEngineUnity/Scripts/VisualScripting/HoudiniEngineUnity.VisualScripting.asmdef
+++ b/Plugins/HoudiniEngineUnity/Scripts/VisualScripting/HoudiniEngineUnity.VisualScripting.asmdef
@@ -13,7 +13,15 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
+    "defineConstraints": [
+        "HAS_VISUALSCRIPTING"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.visualscripting",
+            "expression": "1.5.0",
+            "define": "HAS_VISUALSCRIPTING"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
HEU support for Unity visual scripting assumes visual scripting support is always available in Unity versions >= 2021.1, however this is not the case. Although it is added by default to new projects it's also the first thing to be removed to avoid bloat in projects that don't actually need or want to use visual scripting. It will also not be present in projects upgraded from previous Unity versions unless explicitly added.

This change makes compilation of the visual scripting assemblies conditional on the presence of the visual scripting package in the project.