### PR TITLE
Add missing meta files.

### DIFF
--- a/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIConstants.cs.meta
+++ b/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 949fa796619fef64995213b0a6867791
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIEnums.cs.meta
+++ b/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIEnums.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d946c3a2b0ecea74298feef9c3db1c86
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIFunctions.cs.meta
+++ b/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIFunctions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 319571b76f501074da36a221249bf76e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIStructs.cs.meta
+++ b/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIStructs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e20bf9b384a1a24aa29e0286da6c184
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/HoudiniEngineUnity/Scripts/HEU_HoudiniVersion.cs.meta
+++ b/Plugins/HoudiniEngineUnity/Scripts/HEU_HoudiniVersion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3251d2e51c5b3e4ca1882f71ba3b3f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 238022513fd7a27428860feb9b912763
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Some files in the repo are missing corresponding meta files. Since Unity generates these on import, this creates local modifications to the plugin every time it's added to a project.