### PR TITLE
Add package manifest for pulling HEU through UPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ Currently, the supported Unity versions are:
 1. Copy the Plugins/HoudiniEngineUnity folder from the cloned repository from step 2, and paste it into your Unity project's Assets/Plugins folder. If the Plugins folder exists, you can simply merge with it.
 1. Restart Unity.
 1. Ensure Houdini Engine loaded successfully by going to the "HoudiniEngine" top menu and selecting "Installation Info" and making sure all the versions match.
+
+## Installing from GitHub
+
+Note: Installing Unity packages directly from Git requires a git binary to be installed on the system and is only supported in Unity 2019.1 or newer. The process is described in detail in [Unity's documentation](https://docs.unity3d.com/2021.3/Documentation/Manual/upm-git.html).
+
+1. Open package manager window in Unity 'Windows -> Package Manager'
+2. Click the + icon in the top-left corner, choose the 'Add package from git URL...' option
+3. Enter the appropriate URL for the repository/branch/revision you'd like to add to the project - see Unity's docs for all available options. E.g. to add the latest official version of the plugin for Houdini 19, enter the URL 'https://github.com/sideeffects/HoudiniEngineForUnity.git#Houdini19.0'. If you've forked the repo, replace the base URL with your own repository.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "com.sesi.houdiniengineforunity",
+  "version": "19.0.505",
+  "unity": "2019.1",
+  "displayName": "Houdini Engine",
+  "description": "Houdini Engine for Unity is a Unity plug-in that allows deep integration of Houdini technology into Unity through the use of Houdini Engine.",
+  "dependencies": {}
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c02dc8092665b9842b2e5dcdd0eec978
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This change allows HEU to be added to a project as a package instead of a folder hierarchy manually copied inside Assets/.

A side effect of the change is that the plugin can now be installed and updated directly from Git(Hub) without requiring any manual steps - this is especially useful for teams that fork and modify HEU as it can be pulled directly from their source control (or from a scoped package registry if that's preferred).

IMHO this is the preferred way of adding middleware/plugins to Unity projects as it keep the Assets/ folder clean from external tools and reserves it exclusively for project content.