### PR TITLE
Fixed an issue with mesh normals when Unity exports them to Houdini

### DIFF
--- a/Plugins/HoudiniEngineUnity/Scripts/Asset/HEU_ObjectNode.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Asset/HEU_ObjectNode.cs
@@ -498,11 +498,19 @@ namespace HoudiniEngineUnity
 		int numPostCookGeoInfos = postCookGeoInfos.Count;
 		for (int i = 0; i < numPostCookGeoInfos; i++)
 		{
+		    string geoName = HEU_SessionManager.GetString(postCookGeoInfos[i].nameSH, session);
+
 		    bool bFound = false;
 		    for (int j = 0; j < _geoNodes.Count; j++)
 		    {
-			string geoName = HEU_SessionManager.GetString(postCookGeoInfos[i].nameSH, session);
-			if (geoName.Equals(_geoNodes[j].GeoName))
+			string oldGeoName = _geoNodes[j].GeoName;
+
+			if (geoName.Equals(oldGeoName)
+			    // Fixes Bug #124004
+			    // Newly created curves all use "curve" for their geo name, 
+			    // but loaded curves use "curveX", this caused loaded curves to disappear if recooked
+			    // due to the saved name for the geo being "curve" and the newly created node name to be "curveX"
+			    || (oldGeoName.Equals("curve") && geoName.StartsWith("curve")))
 			{
 			    _geoNodes[j].SetGeoInfo(postCookGeoInfos[i]);
 

--- a/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIEnums.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIEnums.cs
@@ -609,6 +609,8 @@ namespace HoudiniEngineUnity
         HAPI_PDG_EVENT_SCHEDULER_REMOVED,        //Sent when a scheduler is removed from the graph
         HAPI_PDG_EVENT_SET_SCHEDULER,        //Deprecated
         HAPI_PDG_EVENT_SERVICE_MANAGER_ALL,        //Deprecated
+        HAPI_PDG_EVENT_NODE_COOKED,        //Sent when a node finishes cooking
+        HAPI_PDG_EVENT_NODE_GENERATED,        //Sent when a node finished generating
         HAPI_PDG_CONTEXT_EVENTS,        
     };
 

--- a/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIFunctions.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIFunctions.cs
@@ -447,6 +447,24 @@ namespace HoudiniEngineUnity
                 int choice_length);
         [DllImport(HEU_HoudiniVersion.HAPI_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern HAPI_Result
+        HAPI_GetLoadedAssetLibraryCount(
+                ref HAPI_Session session,
+                out int count);
+        [DllImport(HEU_HoudiniVersion.HAPI_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        public static extern HAPI_Result
+        HAPI_GetAssetLibraryIds(
+                ref HAPI_Session session,
+                [Out] HAPI_AssetLibraryId[] asset_library_ids_array,
+                int start,
+                int length);
+        [DllImport(HEU_HoudiniVersion.HAPI_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        public static extern HAPI_Result
+        HAPI_GetAssetLibraryFilePath(
+                ref HAPI_Session session,
+                HAPI_AssetLibraryId asset_library_id,
+                out HAPI_StringHandle file_path_sh);
+        [DllImport(HEU_HoudiniVersion.HAPI_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        public static extern HAPI_Result
         HAPI_LoadHIPFile(
                 ref HAPI_Session session,
                 byte[] file_name,

--- a/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIStructs.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/HAPI/HEU_HAPIStructs.cs
@@ -231,6 +231,9 @@ namespace HoudiniEngineUnity
         [MarshalAs(UnmanagedType.U1)]
         public HAPI_Bool cacheMeshTopology;              //This toggle lets you enable the caching of the mesh topology.By default this is false. If this is set to true cooking a meshgeometry will update only the topology if the number of points changed.Use this to get better performance on deforming meshes.
 
+        [MarshalAs(UnmanagedType.U1)]
+        public HAPI_Bool preferOutputNodes;              //If enabled calls to HAPI_CookNode on an OBJ node will cook the outputnodes of any nested SOP nodes. If none exist or the option is disabledHAPI will instead cook the display nodes of any nested SOP nodes.
+
         [MarshalAs(UnmanagedType.I4)]
         public int extraFlags;              //For internal use only. :
 

--- a/Plugins/HoudiniEngineUnity/Scripts/HEU_HoudiniVersion.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/HEU_HoudiniVersion.cs
@@ -41,10 +41,10 @@ namespace HoudiniEngineUnity
         {
                 public const int HOUDINI_MAJOR			= 19;
                 public const int HOUDINI_MINOR			= 5;
-                public const int HOUDINI_BUILD			= 226;
+                public const int HOUDINI_BUILD			= 318;
                 public const int HOUDINI_PATCH			= 0;
 
-                public const string HOUDINI_VERSION_STRING = "19.5.226";
+                public const string HOUDINI_VERSION_STRING = "19.5.318";
 
                 public const int HOUDINI_ENGINE_MAJOR	= 5;
                 public const int HOUDINI_ENGINE_MINOR	= 0;

--- a/Plugins/HoudiniEngineUnity/Scripts/HEU_HoudiniVersion.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/HEU_HoudiniVersion.cs
@@ -41,10 +41,10 @@ namespace HoudiniEngineUnity
         {
                 public const int HOUDINI_MAJOR			= 19;
                 public const int HOUDINI_MINOR			= 5;
-                public const int HOUDINI_BUILD			= 318;
+                public const int HOUDINI_BUILD			= 339;
                 public const int HOUDINI_PATCH			= 0;
 
-                public const string HOUDINI_VERSION_STRING = "19.5.318";
+                public const string HOUDINI_VERSION_STRING = "19.5.339";
 
                 public const int HOUDINI_ENGINE_MAJOR	= 5;
                 public const int HOUDINI_ENGINE_MINOR	= 0;

--- a/Plugins/HoudiniEngineUnity/Scripts/HEU_HoudiniVersion.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/HEU_HoudiniVersion.cs
@@ -41,15 +41,15 @@ namespace HoudiniEngineUnity
         {
                 public const int HOUDINI_MAJOR			= 19;
                 public const int HOUDINI_MINOR			= 5;
-                public const int HOUDINI_BUILD			= 339;
+                public const int HOUDINI_BUILD			= 457;
                 public const int HOUDINI_PATCH			= 0;
 
-                public const string HOUDINI_VERSION_STRING = "19.5.339";
+                public const string HOUDINI_VERSION_STRING = "19.5.457";
 
                 public const int HOUDINI_ENGINE_MAJOR	= 5;
                 public const int HOUDINI_ENGINE_MINOR	= 0;
 
-                public const int HOUDINI_ENGINE_API		= 0;
+                public const int HOUDINI_ENGINE_API		= 5;
 
                 public const int UNITY_PLUGIN_VERSION	= 2;
 

--- a/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_InputInterfaceMesh.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_InputInterfaceMesh.cs
@@ -285,6 +285,7 @@ namespace HoudiniEngineUnity
 	    {
 		Vector3[] meshVertices = inputDataMeshes._inputMeshes[i]._mesh.vertices;
 		Matrix4x4 localToWorld = rootInvertTransformMatrix * inputDataMeshes._inputMeshes[i]._transform.localToWorldMatrix;
+		Matrix4x4 worldToLocalTransposed = localToWorld.inverse.transpose;
 
 		List<Vector3> uniqueVertices = new List<Vector3>();
 
@@ -366,7 +367,11 @@ namespace HoudiniEngineUnity
 
 			if (meshNormals != null && (originalIndex < meshNormals.Length))
 			{
-			    normals.Add(meshNormals[originalIndex]);
+				Vector3 normalLocalSpace = meshNormals[originalIndex];
+				Vector3 normalWorldSpace = worldToLocalTransposed * normalLocalSpace;
+				if (normalWorldSpace.sqrMagnitude > 0f)
+					normalWorldSpace.Normalize();
+				normals.Add(normalWorldSpace);
 			}
 
 			for (int u = 0; u < NumUVSets; ++u)

--- a/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_InputInterfaceTerrain.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_InputInterfaceTerrain.cs
@@ -414,7 +414,12 @@ namespace HoudiniEngineUnity
 			HEU_Logger.LogError("Failed to create input volume node for layer " + layerName);
 			break;
 		    }
-		}
+
+            float[,] heights = idt._terrainData.GetHeights(0, 0, idt._terrainData.heightmapResolution, idt._terrainData.heightmapResolution);
+            int heightsSizeX = heights.GetLength(0);
+            int heightsSizeY = heights.GetLength(1);
+            alphaMapsConverted[m] = HEU_TerrainUtility.ResampleData(alphaMapsConverted[m], sizeX, sizeY, heightsSizeX, heightsSizeY);
+        }
 
 		//HEU_Logger.Log("Uploading terrain layer: " + layerName);
 

--- a/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_TerrainUtility.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_TerrainUtility.cs
@@ -181,6 +181,9 @@ namespace HoudiniEngineUnity
 		if (terrainResizedDelta < 0)
 		{
 		    HEU_Logger.LogWarningFormat("Note that Unity automatically resized terrain resolution to {0} from {1}. Use terrain size of power of two plus 1, and grid spacing of 2.", heightMapResolution, terrainData.heightmapResolution);
+		    float[] resampledHeights = HEU_TerrainUtility.ResampleData(normalizedHeights, heightMapResolution, heightMapResolution, terrainData.heightmapResolution, terrainData.heightmapResolution);
+
+		    normalizedHeights = resampledHeights;
 		    heightMapResolution = terrainData.heightmapResolution;
 		}
 		else if (terrainResizedDelta > 0)


### PR DESCRIPTION
Unity is exporting wrong normals to Houdini at the moment. It converts positions from the local space into the world space, but keeps normals in the local space. I added a local-to-world conversion for normals in this PR.

Keep in mind that we should use a transposed worldToLocal matrix instead of a regular localToWorld matrix with normals to make it work correctly with nonuniform or negative scales.

I made this PR for 19.5 because I'm working with this version of Houdini. But it seems that the same issue is in 20.5 as well.
