### PR TITLE
Fixed an issue with mesh normals when Unity exports them to Houdini

### DIFF
--- a/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_InputInterfaceMesh.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_InputInterfaceMesh.cs
@@ -285,6 +285,7 @@ namespace HoudiniEngineUnity
 	    {
 		Vector3[] meshVertices = inputDataMeshes._inputMeshes[i]._mesh.vertices;
 		Matrix4x4 localToWorld = rootInvertTransformMatrix * inputDataMeshes._inputMeshes[i]._transform.localToWorldMatrix;
+		Matrix4x4 worldToLocalTransposed = localToWorld.inverse.transpose;
 
 		List<Vector3> uniqueVertices = new List<Vector3>();
 
@@ -366,7 +367,11 @@ namespace HoudiniEngineUnity
 
 			if (meshNormals != null && (originalIndex < meshNormals.Length))
 			{
-			    normals.Add(meshNormals[originalIndex]);
+				Vector3 normalLocalSpace = meshNormals[originalIndex];
+				Vector3 normalWorldSpace = worldToLocalTransposed * normalLocalSpace;
+				if (normalWorldSpace.sqrMagnitude > 0f)
+					normalWorldSpace.Normalize();
+				normals.Add(normalWorldSpace);
 			}
 
 			for (int u = 0; u < NumUVSets; ++u)


### PR DESCRIPTION
Unity is exporting wrong normals to Houdini at the moment. It converts positions from the local space into the world space, but keeps normals in the local space. I added a local-to-world conversion for normals in this PR.

Keep in mind that we should use a transposed worldToLocal matrix instead of a regular localToWorld matrix with normals to make it work correctly with nonuniform or negative scales.

I made this PR for 19.5 because I'm working with this version of Houdini. But it seems that the same issue is in 20.5 as well.