### PR TITLE
Fixed compiler errors on incorrect [SerializeField] attributes ...

### DIFF
--- a/Plugins/HoudiniEngineUnity/Scripts/Asset/HEU_HoudiniAsset.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Asset/HEU_HoudiniAsset.cs
@@ -595,7 +595,7 @@ namespace HoudiniEngineUnity
 
         [SerializeField] private HEU_InstanceInputUIState _instanceInputUIState;
 
-        [field: SerializeField]
+		//! No attribute needed here (explicit field already serialized above)
         internal HEU_InstanceInputUIState InstanceInputUIState
         {
             get { return _instanceInputUIState; }
@@ -5680,3 +5680,4 @@ namespace HoudiniEngineUnity
         }
     }
 } // HoudiniEngineUnity
+

--- a/Plugins/HoudiniEngineUnity/Scripts/Asset/HEU_HoudiniAsset.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Asset/HEU_HoudiniAsset.cs
@@ -565,7 +565,7 @@ namespace HoudiniEngineUnity
 
         [SerializeField] private long _sessionID = HEU_SessionData.INVALID_SESSION_ID;
 
-        [SerializeField] internal bool WarnedPrefabNotSupported { get; set; }
+        [field: SerializeField] internal bool WarnedPrefabNotSupported { get; set; }
 
         // UI TOGGLES -------------------------------------------------------------------------------------------------
 
@@ -595,7 +595,7 @@ namespace HoudiniEngineUnity
 
         [SerializeField] private HEU_InstanceInputUIState _instanceInputUIState;
 
-        [SerializeField]
+        [field: SerializeField]
         internal HEU_InstanceInputUIState InstanceInputUIState
         {
             get { return _instanceInputUIState; }


### PR DESCRIPTION
The C# `[SerializeField]` attribute in Unity is only allowed on fields, not the `get`/`set` methods of a property, therefore when serializing the backing field of an auto-property (implicit backing field generated by Roslyn), it is necessary to use the `field:` specifier to target that generated field:

```cs
[SerializeField] public int Counter { get; set; } //! ERROR
[field: SerializeField] public int Counter { get; set; } //! OK
```