### PR TITLE
Fix: Use linear curve type for splines with all-linear knots

### DIFF
--- a/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_InputInterfaceSpline.cs
+++ b/Plugins/HoudiniEngineUnity/Scripts/Utility/HEU_InputInterfaceSpline.cs
@@ -233,6 +233,7 @@ namespace HoudiniEngineUnity
             public int _count;
             public float _length;
             public BezierKnot[] _knots;
+            public bool _allKnotsLinear;
         }
 
         /// <summary>
@@ -265,6 +266,18 @@ namespace HoudiniEngineUnity
                 splineData._length = spline.GetLength();
                 splineData._knots = spline.Knots.ToArray<BezierKnot>();
 
+                // Check if all knots use linear tangent mode
+                bool allLinear = spline.Count > 0;
+                for (int i = 0; i < spline.Count; i++)
+                {
+                    if (spline.GetTangentMode(i) != TangentMode.Linear)
+                    {
+                        allLinear = false;
+                        break;
+                    }
+                }
+                splineData._allKnotsLinear = allLinear;
+
                 splineContainerData._inputSplines.Add(splineData);
             }
             splineContainerData._transform = inputObject.transform;
@@ -283,8 +296,16 @@ namespace HoudiniEngineUnity
         {
             // Set the input curve info of the newly created input curve
             HAPI_InputCurveInfo inputCurveInfo = new HAPI_InputCurveInfo();
-            inputCurveInfo.curveType = HAPI_CurveType.HAPI_CURVETYPE_BEZIER;
-            inputCurveInfo.order = 4;
+            if (inputSpline._allKnotsLinear)
+            {
+                inputCurveInfo.curveType = HAPI_CurveType.HAPI_CURVETYPE_LINEAR;
+                inputCurveInfo.order = 2;
+            }
+            else
+            {
+                inputCurveInfo.curveType = HAPI_CurveType.HAPI_CURVETYPE_BEZIER;
+                inputCurveInfo.order = 4;
+            }
             inputCurveInfo.closed = inputSpline._closed;
             inputCurveInfo.reverse = false;
             inputCurveInfo.inputMethod = HAPI_InputCurveMethod.HAPI_CURVEMETHOD_BREAKPOINTS;


### PR DESCRIPTION
## Summary

`HEU_InputInterfaceSpline.UploadData()` always sends `HAPI_CURVETYPE_BEZIER` (order 4) regardless of the Unity Spline knot `TangentMode`. This causes linear splines to be converted to Bezier curves in Houdini, changing their intended shape.

## Steps to reproduce

1. In Unity, create a `SplineContainer` with all knots set to `TangentMode.Linear`
2. Connect it as a SPLINE input to an HDA
3. Cook the HDA
4. **Actual**: The curve is received as Bezier in Houdini — the straight-line shape is lost
5. **Expected**: The curve should be received as Linear, preserving the shape

## Fix

- Add `_allKnotsLinear` field to `HEU_InputDataSpline`
- In `GenerateSplineDataFromGameObject()`, check `ISpline.GetTangentMode()` for each knot
- In `UploadData()`, use `HAPI_CURVETYPE_LINEAR` (order 2) when all knots are linear; otherwise use the existing Bezier path

This is a minimal change (1 file, ~20 lines added) with no impact on existing Bezier spline behavior.